### PR TITLE
Fix quirk with negative cost values since last reading

### DIFF
--- a/custom_components/green_button/__init__.py
+++ b/custom_components/green_button/__init__.py
@@ -86,11 +86,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Clean up coordinator
         hass.data[DOMAIN].pop(entry.entry_id, None)
 
-        # Clean up and remove XML storage instance and file if it exists
+        # Discard the in-memory XML storage object but do NOT delete the file.
+        # The storage file on disk is the only persistent copy of the gas XML data
+        # and must survive reloads (e.g. options changes).  Deleting it here would
+        # permanently lose all imported data on every reload.
         storage_key = f"{DOMAIN}_xml_storage_{entry.entry_id}"
-        xml_storage = hass.data[DOMAIN].pop(storage_key, None)
-        if xml_storage:
-            await xml_storage.async_remove()
+        hass.data[DOMAIN].pop(storage_key, None)
 
         # If no more entries, unload services
         if not hass.data[DOMAIN]:

--- a/custom_components/green_button/coordinator.py
+++ b/custom_components/green_button/coordinator.py
@@ -406,21 +406,38 @@ class GreenButtonCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 existing_up = existing_up_map[new_up.id]
                 self._merge_meter_readings(existing_up, list(new_up.meter_readings))
                 # Merge usage summaries (unique by id)
-                existing_summaries = {us.id: us for us in existing_up.usage_summaries}
+                existing_summaries = {
+                    us.id: us for us in existing_up.usage_summaries if getattr(us, "id", None)
+                }
                 merged_summaries = list(existing_up.usage_summaries)
                 added = 0
+                skipped_duplicates = 0
                 for us in new_up.usage_summaries:
-                    if us.id not in existing_summaries:
-                        merged_summaries.append(us)
-                        added += 1
-                if added:
+                    us_id = getattr(us, "id", None)
+                    if us_id and us_id in existing_summaries:
+                        skipped_duplicates += 1
+                        continue
+                    merged_summaries.append(us)
+                    if us_id:
+                        existing_summaries[us_id] = us
+                    added += 1
+                if added or skipped_duplicates:
+                    merged_summaries.sort(
+                        key=lambda us: (
+                            getattr(us, "start", None) or 0,
+                            str(getattr(us, "duration", None) or ""),
+                            getattr(us, "id", "") or "",
+                        )
+                    )
                     merged_up = dataclasses.replace(existing_up, usage_summaries=merged_summaries)
                     self.usage_points = [merged_up if up.id == existing_up.id else up for up in self.usage_points]
                 _LOGGER.info(
-                    "[MERGE] Merged usage point %s: %d meter readings, %d usage summaries",
+                    "[MERGE] Merged usage point %s: %d meter readings, %d usage summaries (added=%d skipped_duplicates=%d)",
                     new_up.id,
                     len(existing_up.meter_readings),
                     len(merged_summaries),
+                    added,
+                    skipped_duplicates,
                 )
             else:
                 # Add new usage point
@@ -543,8 +560,17 @@ class GreenButtonCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return meter_readings
 
     def get_usage_summaries_for_meter_reading(self, meter_reading_id: str) -> list[model.UsageSummary]:
-        """Get usage summaries for the usage point that owns the meter reading."""
+        """Get usage summaries for the usage point that owns the meter reading.
+
+        Accepts either a meter_reading.id or a usage_point.id (the latter is
+        used by GreenButtonGasCostSensor when the XML contains only
+        UsageSummaries and no interval-block MeterReadings).
+        """
         for usage_point in self.usage_points:
+            # Direct match on usage_point.id (summaries-only XML path)
+            if usage_point.id == meter_reading_id:
+                return list(getattr(usage_point, "usage_summaries", []) or [])
+            # Original path: match via meter_reading.id
             for meter_reading in usage_point.meter_readings:
                 if meter_reading.id == meter_reading_id:
                     return list(getattr(usage_point, "usage_summaries", []) or [])

--- a/custom_components/green_button/sensor.py
+++ b/custom_components/green_button/sensor.py
@@ -52,6 +52,8 @@ def _schedule_hass_task_from_any_thread(hass: HomeAssistant, coro) -> None:
 class GreenButtonSensor(CoordinatorEntity[GreenButtonCoordinator], SensorEntity):
     """A sensor for Green Button energy data."""
 
+    suppress_auto_state_write = True
+
     _attr_device_class = SensorDeviceClass.ENERGY
     # We set state_class to satisfy HA's validation (prevents "fix issue" warnings)
     # but we return None from native_value so there's no state history for HA
@@ -327,11 +329,8 @@ class GreenButtonSensor(CoordinatorEntity[GreenButtonCoordinator], SensorEntity)
             )
             self._cached_native_value = total_energy
 
-            # Write the state once after statistics import to update the sensor display
-            self.async_write_ha_state()
-
             _LOGGER.info(
-                "%s: Statistics update completed, state set to %.2f kWh.",
+                "%s: Statistics update completed; cached state now %.2f kWh (state write suppressed to avoid recorder auto-stat corruption).",
                 self.entity_id,
                 self._cached_native_value,
             )
@@ -344,6 +343,8 @@ class GreenButtonSensor(CoordinatorEntity[GreenButtonCoordinator], SensorEntity)
 
 class GreenButtonCostSensor(CoordinatorEntity[GreenButtonCoordinator], SensorEntity):
     """A sensor for Green Button monetary cost data (total)."""
+
+    suppress_auto_state_write = True
 
     _attr_device_class = SensorDeviceClass.MONETARY
     # Set state_class to TOTAL (not TOTAL_INCREASING) for monetary sensors
@@ -590,10 +591,9 @@ class GreenButtonCostSensor(CoordinatorEntity[GreenButtonCoordinator], SensorEnt
 class GreenButtonGasSensor(CoordinatorEntity[GreenButtonCoordinator], SensorEntity):
     """Gas consumption sensor (m³, total increasing)."""
 
+    suppress_auto_state_write = True
+
     _attr_device_class = SensorDeviceClass.GAS
-    # We set state_class to satisfy HA's validation (prevents "fix issue" warnings)
-    # but we return None from native_value so there's no state history for HA
-    # to auto-compile. We manually import statistics via async_import_statistics().
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_native_unit_of_measurement = "m³"
     _attr_has_entity_name = True
@@ -789,11 +789,8 @@ class GreenButtonGasSensor(CoordinatorEntity[GreenButtonCoordinator], SensorEnti
             )
             self._cached_native_value = total
 
-            # Write the state once after statistics import to update the sensor display
-            self.async_write_ha_state()
-
             _LOGGER.info(
-                "%s: Gas statistics update completed, state set to %.2f m³.",
+                "%s: Gas statistics update completed; cached state now %.2f m³ (state write suppressed to avoid recorder auto-stat corruption).",
                 self.entity_id,
                 self._cached_native_value,
             )
@@ -859,11 +856,8 @@ class GreenButtonGasSensor(CoordinatorEntity[GreenButtonCoordinator], SensorEnti
             total = sum(us.consumption_m3 or 0.0 for us in usage_point.usage_summaries)
             self._cached_native_value = total if total > 0 else 0.0
 
-            # Write the state once after statistics import to update the sensor display
-            self.async_write_ha_state()
-
             _LOGGER.info(
-                "%s: Gas statistics update (from summaries) completed, state set to %.2f m³.",
+                "%s: Gas statistics update (from summaries) completed; cached state now %.2f m³ (state write suppressed to avoid recorder auto-stat corruption).",
                 self.entity_id,
                 self._cached_native_value,
             )
@@ -877,10 +871,9 @@ class GreenButtonGasSensor(CoordinatorEntity[GreenButtonCoordinator], SensorEnti
 class GreenButtonGasCostSensor(CoordinatorEntity[GreenButtonCoordinator], SensorEntity):
     """Gas cost sensor (monetary total) using UsageSummary pro-rated per day."""
 
+    suppress_auto_state_write = True
+
     _attr_device_class = SensorDeviceClass.MONETARY
-    # Set state_class to TOTAL (not TOTAL_INCREASING) for monetary sensors
-    # Monetary values can decrease (refunds, adjustments), so use TOTAL
-    # We disable recorder statistics for this entity and manually manage via async_import_statistics
     _attr_state_class = SensorStateClass.TOTAL
     _attr_has_entity_name = True
 
@@ -1133,6 +1126,12 @@ async def async_setup_entry(
         )
 
         for entity in created_entities:
+            if getattr(entity, "suppress_auto_state_write", False):
+                _LOGGER.info(
+                    "Skipping async_write_ha_state() on newly created sensor %s because it manages recorder statistics manually",
+                    getattr(entity, "entity_id", "UNKNOWN"),
+                )
+                continue
             _LOGGER.info(
                 "Calling async_write_ha_state() on newly created sensor %s",
                 getattr(entity, "entity_id", "UNKNOWN"),

--- a/custom_components/green_button/services.py
+++ b/custom_components/green_button/services.py
@@ -418,7 +418,38 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                                     existing_up = usage_points[existing_idx]
                                     # Combine meter readings and usage summaries (UsagePoint is frozen, must use replace)
                                     combined_mrs = list(existing_up.meter_readings) + list(new_up.meter_readings)
-                                    combined_summaries = list(existing_up.usage_summaries) + list(new_up.usage_summaries)
+                                    summary_map = {
+                                        us.id: us for us in existing_up.usage_summaries if getattr(us, "id", None)
+                                    }
+                                    no_id_summaries = [
+                                        us for us in existing_up.usage_summaries if not getattr(us, "id", None)
+                                    ]
+                                    skipped_duplicates = 0
+                                    for us in new_up.usage_summaries:
+                                        us_id = getattr(us, "id", None)
+                                        if us_id:
+                                            if us_id in summary_map:
+                                                skipped_duplicates += 1
+                                                continue
+                                            summary_map[us_id] = us
+                                        else:
+                                            no_id_summaries.append(us)
+                                    combined_summaries = list(summary_map.values()) + no_id_summaries
+                                    combined_summaries.sort(
+                                        key=lambda us: (
+                                            getattr(us, "start", None) or 0,
+                                            str(getattr(us, "duration", None) or ""),
+                                            getattr(us, "id", "") or "",
+                                        )
+                                    )
+                                    _LOGGER.warning(
+                                        "[GB DEBUG] recalculation merge usage_point=%s combined_summaries=%d existing=%d new=%d skipped_duplicates=%d",
+                                        new_up.id,
+                                        len(combined_summaries),
+                                        len(existing_up.usage_summaries),
+                                        len(new_up.usage_summaries),
+                                        skipped_duplicates,
+                                    )
                                     
                                     # Create new UsagePoint with combined data
                                     merged_up = replace(

--- a/custom_components/green_button/statistics.py
+++ b/custom_components/green_button/statistics.py
@@ -2224,6 +2224,26 @@ async def update_gas_cost_statistics(
     if not records:
         return
 
+    # Append a zero-state sentinel for today so HA never computes a negative daily delta.
+    # When data only covers up to a few days ago, the last record's cumulative sum is S.
+    # Without a record for today, HA sees sum drop from S to 0 and shows -S as today's cost.
+    # The sentinel carries the last sum forward with state=0 so the delta reads as $0.
+    today_midnight = datetime.datetime.combine(
+        datetime.date.today(), datetime.time.min, tzinfo=tzinfo
+    )
+    last_record = records[-1]
+    if last_record["start"] < today_midnight:
+        records.append({
+            "start": today_midnight,
+            "state": 0.0,
+            "sum": float(last_record["sum"]),
+        })
+        _LOGGER.debug(
+            "Appended today sentinel for %s (sum=%.2f)",
+            entity.entity_id,
+            last_record["sum"],
+        )
+
     # Clear all existing statistics and reimport with the merged data
     try:
         await _ClearStatisticsTask.queue_task(

--- a/custom_components/green_button/statistics.py
+++ b/custom_components/green_button/statistics.py
@@ -7,6 +7,8 @@ import dataclasses
 import datetime
 import decimal
 import logging
+import sqlite3
+from collections import Counter
 from collections.abc import Callable
 from collections.abc import Sequence
 from typing import Any
@@ -369,6 +371,91 @@ def _find_last_statistic_before(
         if stat["start"] < target_time:
             return stat
     return None
+
+
+def _debug_dump_statistics_records(label: str, records: list[StatisticData]) -> None:
+    """Log a compact debug summary of generated statistic records."""
+    if not records:
+        _LOGGER.warning("[GB DEBUG] %s: no records", label)
+        return
+    total_state = sum(float(r.get("state", 0.0) or 0.0) for r in records)
+    _LOGGER.warning(
+        "[GB DEBUG] %s: count=%d sum(state)=%.5f first=%s state=%.5f sum=%.5f last=%s state=%.5f sum=%.5f",
+        label,
+        len(records),
+        total_state,
+        records[0]["start"],
+        float(records[0].get("state", 0.0) or 0.0),
+        float(records[0].get("sum", 0.0) or 0.0),
+        records[-1]["start"],
+        float(records[-1].get("state", 0.0) or 0.0),
+        float(records[-1].get("sum", 0.0) or 0.0),
+    )
+
+
+def _debug_dump_usage_summaries(entity_id: str, usage_summaries: list[model.UsageSummary]) -> None:
+    """Log duplicate hints and totals for gas cost usage summaries."""
+    ids = [getattr(us, "id", None) for us in usage_summaries]
+    id_dups = {k: v for k, v in Counter(ids).items() if k and v > 1}
+    period_keys = [
+        (
+            getattr(us, "start", None).isoformat() if getattr(us, "start", None) else None,
+            str(getattr(us, "duration", None)),
+            float(getattr(us, "total_cost", 0.0) or 0.0),
+        )
+        for us in usage_summaries
+    ]
+    period_dups = {k: v for k, v in Counter(period_keys).items() if v > 1}
+    total_cost = sum(float(getattr(us, "total_cost", 0.0) or 0.0) for us in usage_summaries)
+    _LOGGER.warning(
+        "[GB DEBUG] usage_summaries entity=%s count=%d total_cost=%.5f duplicate_ids=%s duplicate_periods=%s",
+        entity_id,
+        len(usage_summaries),
+        total_cost,
+        id_dups,
+        period_dups,
+    )
+    for us in usage_summaries:
+        _LOGGER.warning(
+            "[GB DEBUG] usage_summary entity=%s id=%s start=%s duration=%s total_cost=%.5f consumption_m3=%s",
+            entity_id,
+            getattr(us, "id", None),
+            getattr(us, "start", None),
+            getattr(us, "duration", None),
+            float(getattr(us, "total_cost", 0.0) or 0.0),
+            getattr(us, "consumption_m3", None),
+        )
+
+
+def _debug_dump_db_statistics(hass: HomeAssistant, statistic_id: str) -> None:
+    """Inspect recorder DB rows after import for one statistic id."""
+    try:
+        db_path = hass.config.path("home-assistant_v2.db")
+        conn = sqlite3.connect(db_path)
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                "select start_ts, state, sum from statistics where metadata_id=(select id from statistics_meta where statistic_id=? limit 1) order by start_ts asc",
+                (statistic_id,),
+            )
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+        if not rows:
+            _LOGGER.warning("[GB DEBUG] db_post_import %s: no rows", statistic_id)
+            return
+        total_state = sum(float(r[1] or 0.0) for r in rows)
+        _LOGGER.warning(
+            "[GB DEBUG] db_post_import %s: count=%d sum(state)=%.5f final_sum=%.5f first=%s last=%s",
+            statistic_id,
+            len(rows),
+            total_state,
+            float(rows[-1][2] or 0.0),
+            rows[0],
+            rows[-1],
+        )
+    except Exception:
+        _LOGGER.exception("[GB DEBUG] failed db inspection for %s", statistic_id)
 
 
 def _calculate_running_sum(stats: list[StatisticData]) -> list[StatisticData]:
@@ -1966,6 +2053,20 @@ async def update_gas_statistics(
             if period_m3 is None or period_m3 <= 0:
                 continue
 
+            # Guard: skip any record in the future or at/after today's midnight.
+            # Billing periods should only produce records for completed months.
+            today_midnight_guard = datetime.datetime.combine(
+                datetime.date.today(), datetime.time.min, tzinfo=tzinfo
+            )
+            if rec_start >= today_midnight_guard:
+                _LOGGER.warning(
+                    "Gas %s: Skipping record at %s (>= today midnight %s) to prevent future-date stats corruption",
+                    entity.entity_id,
+                    rec_start,
+                    today_midnight_guard,
+                )
+                continue
+
             records.append({"start": rec_start, "state": period_m3, "sum": 0.0})
 
         if not records:
@@ -2079,6 +2180,7 @@ async def update_gas_cost_statistics(
         entity.entity_id,
         merge_with_existing,
     )
+    _debug_dump_usage_summaries(entity.entity_id, usage_summaries)
     
     # Calculate the adjustment multiplier
     # Parser applies 10^-3, user wants 10^gas_cost_multiplier
@@ -2099,10 +2201,21 @@ async def update_gas_cost_statistics(
         # Build records sorted by period end
         summaries_sorted = sorted(usage_summaries, key=lambda s: s.start + s.duration)
         new_statistics_data: list[StatisticData] = []
+        today_midnight_cost_guard = datetime.datetime.combine(
+            datetime.date.today(), datetime.time.min, tzinfo=tzinfo
+        )
         for us in summaries_sorted:
             period_end = us.start + us.duration
             # Place the increment at 00:00 of the period end date (the day the period ends)
             rec_start = datetime.datetime.combine(period_end.date(), datetime.time.min, tzinfo=tzinfo)
+            # Guard: skip any record at or after today's midnight (billing periods should be finalized)
+            if rec_start >= today_midnight_cost_guard:
+                _LOGGER.warning(
+                    "Gas Cost %s: Skipping record at %s (>= today midnight) to prevent future-date stats corruption",
+                    entity.entity_id,
+                    rec_start,
+                )
+                continue
             new_statistics_data.append({
                 "start": rec_start,
                 "state": float(us.total_cost * adjustment_multiplier),
@@ -2111,6 +2224,8 @@ async def update_gas_cost_statistics(
 
         if not new_statistics_data:
             return
+
+        _debug_dump_statistics_records(f"{entity.entity_id} monthly_increment new_statistics_data", new_statistics_data)
 
         # Get all existing statistics for this entity (only if merging)
         if merge_with_existing:
@@ -2202,6 +2317,8 @@ async def update_gas_cost_statistics(
             })
 
         # Get all existing statistics for this entity (only if merging)
+        _debug_dump_statistics_records(f"{entity.entity_id} pro_rate_daily new_statistics_data", new_statistics_data)
+
         if merge_with_existing:
             existing_stats = await _get_all_existing_statistics(
                 hass,
@@ -2223,6 +2340,8 @@ async def update_gas_cost_statistics(
 
     if not records:
         return
+
+    _debug_dump_statistics_records(f"{entity.entity_id} records_pre_sentinel", records)
 
     # Append a zero-state sentinel for today so HA never computes a negative daily delta.
     # When data only covers up to a few days ago, the last record's cumulative sum is S.
@@ -2258,7 +2377,9 @@ async def update_gas_cost_statistics(
         _LOGGER.exception("Failed to clear gas cost stats for %s", entity.entity_id)
 
     try:
+        _debug_dump_statistics_records(f"{entity.entity_id} records_import_payload", records)
         async_import_statistics(hass, metadata, records)
         _LOGGER.info("Imported %d gas cost records for %s", len(records), entity.entity_id)
+        _debug_dump_db_statistics(hass, entity.long_term_statistics_id)
     except Exception:
         _LOGGER.exception("Failed to import gas cost stats for %s", entity.entity_id)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -129,3 +129,12 @@ def test_get_usage_summaries_accepts_usage_point_id_for_summaries_only_path() ->
 
     summaries = coord.get_usage_summaries_for_meter_reading("up1")
     assert [summary.id for summary in summaries] == ["jan", "feb"]
+
+
+def test_green_button_gas_sensor_suppresses_auto_state_writes() -> None:
+    from custom_components.green_button.sensor import GreenButtonGasSensor
+
+    coord = _make_coordinator()
+    gas_sensor = GreenButtonGasSensor(coord, "up1")
+
+    assert gas_sensor.suppress_auto_state_write is True

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
 
-"""Unit tests for coordinator.py in green_button integration."""
-import sys
 import asyncio
+import datetime as dt
+import sys
 from unittest.mock import MagicMock, patch
-from custom_components.green_button import coordinator
+
+from homeassistant.components import sensor
+
+from custom_components.green_button import coordinator, model
 
 
 def test_green_button_coordinator_init_sets_attributes():
@@ -22,11 +26,12 @@ def test_green_button_coordinator_update_data_calls_async_update(monkeypatch):
     mock_hass = MagicMock()
     mock_config_entry = MagicMock()
     mock_config_entry.data = {"name": "Test", "usage_point_id": "up1"}
+
     async def fake_async_update_data(self):
         return {"data": 123}
+
     monkeypatch.setattr(coordinator.GreenButtonCoordinator, "_async_update_data", fake_async_update_data)
     coord = coordinator.GreenButtonCoordinator(mock_hass, mock_config_entry)
-    # Run the coroutine
     if sys.version_info >= (3, 8):
         result = asyncio.run(coord._async_update_data())
     else:
@@ -39,12 +44,12 @@ def test_green_button_coordinator_handle_update_error(monkeypatch):
     mock_hass = MagicMock()
     mock_config_entry = MagicMock()
     mock_config_entry.data = {"name": "Test", "usage_point_id": "up1"}
+
     async def fail_update(self):
         raise Exception("fail")
+
     monkeypatch.setattr(coordinator.GreenButtonCoordinator, "_async_update_data", fail_update)
     coord = coordinator.GreenButtonCoordinator(mock_hass, mock_config_entry)
-    import sys
-    import asyncio
     if sys.version_info >= (3, 8):
         try:
             asyncio.run(coord._async_update_data())
@@ -56,3 +61,71 @@ def test_green_button_coordinator_handle_update_error(monkeypatch):
             loop.run_until_complete(coord._async_update_data())
         except Exception as e:
             assert str(e) == "fail"
+
+
+def _make_coordinator() -> coordinator.GreenButtonCoordinator:
+    mock_hass = MagicMock()
+    mock_config_entry = MagicMock()
+    mock_config_entry.data = {"name": "Test", "usage_point_id": "up1"}
+    return coordinator.GreenButtonCoordinator(mock_hass, mock_config_entry)
+
+
+def _reading_type() -> model.ReadingType:
+    return model.ReadingType(
+        id="rt1",
+        commodity=1,
+        currency="CAD",
+        power_of_ten_multiplier=0,
+        unit_of_measurement="kWh",
+        interval_length=3600,
+    )
+
+
+def _usage_summary(summary_id: str, start_day: int, total_cost: float) -> model.UsageSummary:
+    return model.UsageSummary(
+        id=summary_id,
+        start=dt.datetime(2025, 1, start_day, tzinfo=dt.timezone.utc),
+        duration=dt.timedelta(days=30),
+        total_cost=total_cost,
+        currency="CAD",
+        consumption_m3=100.0,
+    )
+
+
+def _usage_point(summary_items: list[model.UsageSummary]) -> model.UsagePoint:
+    meter = model.MeterReading(id="mr1", reading_type=_reading_type(), interval_blocks=[])
+    return model.UsagePoint(
+        id="up1",
+        sensor_device_class=sensor.SensorDeviceClass.GAS,
+        meter_readings=[meter],
+        usage_summaries=summary_items,
+    )
+
+
+def test_merge_usage_points_dedupes_usage_summaries_by_id() -> None:
+    coord = _make_coordinator()
+
+    jan = _usage_summary("jan", 1, 10.0)
+    feb = _usage_summary("feb", 2, 20.0)
+    feb_dupe = _usage_summary("feb", 2, 20.0)
+    mar = _usage_summary("mar", 3, 30.0)
+
+    coord.usage_points = [_usage_point([jan, feb])]
+    coord._merge_usage_points([_usage_point([feb_dupe, mar])])
+
+    merged = list(coord.usage_points[0].usage_summaries)
+    assert [summary.id for summary in merged] == ["jan", "feb", "mar"]
+    assert [summary.total_cost for summary in merged] == [10.0, 20.0, 30.0]
+
+
+def test_get_usage_summaries_accepts_usage_point_id_for_summaries_only_path() -> None:
+    coord = _make_coordinator()
+
+    jan = _usage_summary("jan", 1, 10.0)
+    feb = _usage_summary("feb", 2, 20.0)
+    usage_point = _usage_point([jan, feb])
+
+    coord.usage_points = [usage_point]
+
+    summaries = coord.get_usage_summaries_for_meter_reading("up1")
+    assert [summary.id for summary in summaries] == ["jan", "feb"]


### PR DESCRIPTION
Got this working with enbridge, but without this fix it would show for the current day a negative value for all my prior usage.

This also broke reporting, eg, for the last year, as the negative value exactly offset all the prior usage. Now it works:

<img width="1563" height="536" alt="image" src="https://github.com/user-attachments/assets/c5034d9a-e058-454a-9fa3-583f18d16a26" />

Also note, for enbridge the cost scale should be -3:

<img width="327" height="101" alt="image" src="https://github.com/user-attachments/assets/eb270c01-c6a1-41c4-8130-d3dc9e08aa66" />
